### PR TITLE
Fix Scala #lines method overriden by Java 11's String#lines.

### DIFF
--- a/src/main/scala/Echo.scala
+++ b/src/main/scala/Echo.scala
@@ -10,7 +10,7 @@ object Echo {
 
    val failingVerboseDescription = args.zipWithIndex
      .map {
-       case (arg, index) => s"\t$index: '${arg.lines.mkString("\\n")}'"
+       case (arg, index) => s"\t$index: '${arg.linesIterator.mkString("\\n")}'"
      }
      .mkString("Arguments:\n", "\n", "")
    println(failingVerboseDescription)


### PR DESCRIPTION
The fix is to use `linesIterator` instead of `lines`.